### PR TITLE
refactor: decision function

### DIFF
--- a/mlt/models/__init__.py
+++ b/mlt/models/__init__.py
@@ -2,3 +2,4 @@
 
 from .pla import PLA
 from .pocket import Pocket
+from .model import Model

--- a/mlt/models/model.py
+++ b/mlt/models/model.py
@@ -10,17 +10,22 @@ class Model(metaclass=ABCMeta):
 
     _w = None
 
-    @abstractmethod
-    def fit(self, X, y, w=None, w_init_func=weight.init_zeros):
-        """Fit model"""
+    def __init__(self, w):
+        self._w = w
 
-    def _init_weight(self, w, shape, func=weight.init_zeros):
-        """initial or set weight"""
-        if w is None:
-            self._w = func(shape)
-        else:
-            self._w = w
+    @abstractmethod
+    def fit(self, X, y):
+        """Fit model"""
 
     @abstractmethod
     def _decision_function(self, X):
         """Decision function"""
+
+    def _init_weight(self, n, func='zeros'):  # todo: change func to func_name
+        """initial weight"""
+        if self._w is None:
+            self._w = weight.init(func, n)
+
+    def predict(self, X):
+        """predict from input data"""
+        return self._decision_function(X)

--- a/mlt/models/pla.py
+++ b/mlt/models/pla.py
@@ -1,7 +1,6 @@
 """class PLA"""
 import numpy as np
 
-from mlt.utils import weight
 from mlt.stats import scores
 from mlt.utils import random
 from mlt.utils.logging import logger
@@ -13,20 +12,19 @@ class PLA(Model):
 
     _halt_step = 0
 
-    def __init__(self, order='sequence', correct_times=-1, learning_rate=1.0):
+    def __init__(self, w=None, order='sequence', correct_times=-1, learning_rate=1.0):
+        super().__init__(w)
         self._order = order
         self._correct_times = correct_times
         self._learning_rate = learning_rate
 
-    def fit(self, X, y, w=None, w_init_func=weight.init_zeros):
+    def fit(self, X, y):
         """Fit PLA model.
 
         Parameters
         ----------
         X : ndarray
         y : ndarray
-        w : ndarray
-        w_init_func : ndarray
 
         Returns
         -------
@@ -36,7 +34,7 @@ class PLA(Model):
 
         order = random.generate_sequence(self._order, m)
 
-        self._init_weight(w, n, w_init_func)
+        self._init_weight(n)
 
         is_all_x_right = False
         correct_num = 0
@@ -52,7 +50,6 @@ class PLA(Model):
                     self._w += self._learning_rate * y_one * x_one
                     self._halt_step += 1
                     correct_num = 0
-                    # logger.info('the training accuracy is ', scores.cal_accuracy(X, y, self.w_))
                 else:
                     correct_num += 1
 
@@ -62,7 +59,7 @@ class PLA(Model):
 
         logger.info('-------------------------------------')
         logger.info('total _halt_step is %d', self.halt_step_)
-        logger.info('the training accuracy is %f', scores.cal_accuracy(X, y, self.w_))
+        logger.info('the training accuracy is %f', scores.cal_accuracy(self.predict(X), y))
         logger.info('-------------------------------------')
 
         return self

--- a/mlt/models/pocket.py
+++ b/mlt/models/pocket.py
@@ -10,18 +10,16 @@ from .pla import PLA
 class Pocket(PLA):
     """Pocket model"""
 
-    def __init__(self, order='sequence', correct_times=-1, learning_rate=1.0):
-        super().__init__(order, correct_times, learning_rate)
+    def __init__(self, w=None, order='sequence', correct_times=-1, learning_rate=1.0):
+        super().__init__(w, order, correct_times, learning_rate)
 
-    def fit(self, X, y, w=None, w_init_func=weight.init_zeros):
+    def fit(self, X, y):
         """Fit Pocket model
 
         Parameters
         ----------
         X : ndarray
         y : ndarray
-        w : ndarray
-        w_init_func : ndarray
 
         Returns
         -------
@@ -31,12 +29,13 @@ class Pocket(PLA):
 
         order = random.generate_sequence(self._order, m)
 
-        self._init_weight(w, n, w_init_func)
+        self._init_weight(n)
 
         w_bast = weight.init_zeros(n)
 
         is_all_x_right = False
         correct_num = 0
+        accuracy_bast = 0.0
 
         while is_all_x_right is not True:
 
@@ -50,9 +49,11 @@ class Pocket(PLA):
                 if y_predict != y_one:
                     self._w += self._learning_rate * y_one * x_one
                     self._halt_step += 1
-                    accuracy_bast = scores.cal_accuracy(X, y, w_bast)
-                    accuracy = scores.cal_accuracy(X, y, self.w_)
+                    accuracy = scores.cal_accuracy(self.predict(X), y)
                     if accuracy > accuracy_bast:
+                        # you must use the copy function. because _w is a object.
+                        # if you just do this "w_best = self,_w. you give the address to the w_best"
+                        accuracy_bast = accuracy
                         w_bast = self._w.copy()
                     correct_num = 0
                 else:
@@ -66,7 +67,7 @@ class Pocket(PLA):
 
         logger.info('-------------------------------------')
         logger.info('total _halt_step is %d', self.halt_step_)
-        logger.info('the training accuracy is %s', scores.cal_accuracy(X, y, w_bast))
+        logger.info('the training accuracy is %s', scores.cal_accuracy(self.predict(X), y))
         logger.info('-------------------------------------')
 
         return self

--- a/mlt/models/tests/test_pocket.py
+++ b/mlt/models/tests/test_pocket.py
@@ -21,9 +21,9 @@ class PocketTestCase(unittest.TestCase):
         times = 2000
         error_rates = np.zeros(times)
         for i in range(times):
-            pocket = Pocket('random', 50, 1)
+            pocket = Pocket(order='random', correct_times=50, learning_rate=1)
             pocket.fit(x_train, y_train)
-            error_rates[i] = scores.cal_error_rate(x_test, y_test, pocket.w_)
+            error_rates[i] = scores.cal_error_rate(pocket.predict(x_test), y_test)
 
         result = np.average(error_rates)
         logger.info('error rate is %f', result)

--- a/mlt/stats/scores.py
+++ b/mlt/stats/scores.py
@@ -2,22 +2,26 @@
 
 import numpy as np
 
-from mlt.utils.logging import logger
+
+def cal_accuracy(y_predict, y):
+    """cal accuracy
+
+    Parameters
+    ----------
+    y_predict : ndarray
+    y : ndarray
+    """
+    return np.average(y_predict == y)
 
 
-def cal_accuracy(X, y, w):
-    """cal accuracy return percentage"""
-    return np.average(np.sign(X.dot(w)) == y)  # todo: change here to decision function
+def cal_error_rate(y_predict, y):
+    """cal error rate"""
+    return 1.0 - cal_accuracy(y_predict, y)
 
-
-def cal_error_rate(X, Y, w):
-    """cal error rate return percentage"""
-    return 1.0 - cal_accuracy(X, Y, w)
-
-
-def verification(x_train, y_train, x_test, y_test, w):
-    """verification the difference from train and test set"""
-    accuracy_train = cal_accuracy(x_train, y_train, w)
-    accuracy_test = cal_accuracy(x_test, y_test, w)
-    logger.info('train accuracy : ', accuracy_train, '; tests accuracy : ', accuracy_test, '; difference : ',
-                (accuracy_train - accuracy_test))
+# todo: later I will change this function
+# def verification(x_train, y_train, x_test, y_test, w):
+#     """verification the difference from train and test set"""
+#     accuracy_train = cal_accuracy(x_train, y_train, w)
+#     accuracy_test = cal_accuracy(x_test, y_test, w)
+#     logger.info('train accuracy : ', accuracy_train, '; tests accuracy : ', accuracy_test, '; difference : ',
+#                 (accuracy_train - accuracy_test))

--- a/mlt/utils/weight.py
+++ b/mlt/utils/weight.py
@@ -16,3 +16,23 @@ def init_zeros(n):
     """
     w = np.zeros(n, dtype=float)
     return w
+
+
+def init(func, n):
+    """choose a func to init weight
+
+    Parameters
+    ----------
+    func : str
+        func_name
+    n : int
+        features or node number
+
+    Returns
+    -------
+    w : ndarray
+    """
+    w = None
+    if func is 'zeros':
+        w = init_zeros(n)
+    return w


### PR DESCRIPTION
in the beginning, stats. cal_accuracy function did 3 things. one, depend on X and w to predict y. two, compare with real y. three, cal accuracy. but before the first one was just for the pla. so I want to replace it to model's decision function. suddenly, I noticed that was a wrong decision. cal_accuracy function just need to calculate accuracy. prediction is not its function.
during the progress, I found why the parameters of fit function in sklearn just have X and y. because every model has different parameters, for example pocket has correct_time. but all of them need X and y. We need to unity the APIs. and then we can use pipeline. preprocessing, model, predict...
1. fit function: only have X and y, change parameters to __init__
2. w: you can appoint w at __init__ or model init it with default function.
3. add predict function
4. modify cal_accuracy

close #12 